### PR TITLE
Detect missing swift command in install script

### DIFF
--- a/install
+++ b/install
@@ -11,6 +11,11 @@
 
 SWIFTPM_BIN=.swiftpm/bin
 
+if ! command -v swift >/dev/null 2>&1; then
+    echo "Error: 'swift' command not found. Please install Swift."
+    exit 1
+fi
+
 (swift package experimental-uninstall poietic 2> /dev/null) || true
 swift package experimental-install -c debug
 


### PR DESCRIPTION
If `install` script is executed on system without Swift installed, the `install` script outputs:

```bash
$ ./install
./install: 15: swift: not found
./install: 17: [[: not found
Get more information about the command and its subcommands:

    poietic --help
```

This PR adds a more user friendly error message:
```
$ ./install
Error: 'swift' command not found. Please install Swift.
```

Tested environment: Ubuntu 24.04.2 LTS