### PR TITLE
Fix detection of swiftpm binary in PATH

### DIFF
--- a/install
+++ b/install
@@ -19,7 +19,7 @@ fi
 (swift package experimental-uninstall poietic 2> /dev/null) || true
 swift package experimental-install -c debug
 
-if [[ $PATH != *${SWIFTPM_BIN}* ]]; then
+if ! echo "$PATH" | grep --fixed-strings "$SWIFTPM_BIN" >/dev/null 2>&1; then
     echo "WARNING: The directory $HOME/$SWIFTPM_BIN does not seem to be in your PATH."
     echo
     echo "Add the following to the end of your ~/.zshrc or ~/.bashrc file:"


### PR DESCRIPTION
In `/bin/sh` , the `[[ ]]]` testing is officially not supported:

https://www.shellcheck.net/wiki/SC3010

The supported `[ ]` testing however does not support glob/wildcard matching

https://www.shellcheck.net/wiki/SC2081

so in this change, the `grep` command is used instead.

## Problem

This PR solves the following problem during execution of `./install` script:

```shell
$ ./install
Building for debugging...
[1/1] Write swift-version-43D9DAB6D743E50C.txt
Build of product 'poietic' complete! (0.19s)
Executable product `poietic` was successfully installed to /home/rado/.swiftpm/bin/poietic.
./install: 22: [[: not found
Get more information about the command and its subcommands:

    poietic --help
```

## Note

This was detected by running the shellcheck linter

```shell
$ shellcheck install

In install line 22:
if [[ $PATH != *${SWIFTPM_BIN}* ]]; then
   ^-----------------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3010 -- In POSIX sh, [[ ]] is undefined.
```