### PR TITLE
Updated for new raw design loader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "poietic",
-    platforms: [.macOS("14"), .custom("linux", versionString: "1")],
+    platforms: [.macOS("15"), .custom("linux", versionString: "1")],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/openpoiesis/poietic-core", branch: "main"),

--- a/Sources/Commands/Edit/AddNodeCommand.swift
+++ b/Sources/Commands/Edit/AddNodeCommand.swift
@@ -68,7 +68,7 @@ poietic edit add FlowRate name=expenses formula=50
             }
 
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
 
             print("Created node \(object.id) in frame \(trans.id)")
         }

--- a/Sources/Commands/Edit/AlignCommand.swift
+++ b/Sources/Commands/Edit/AlignCommand.swift
@@ -69,7 +69,7 @@ extension PoieticTool {
             align(objects: objects, mode: mode, spacing: spacing)
             
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
         }
     }
 }

--- a/Sources/Commands/Edit/AutoParametersCommand.swift
+++ b/Sources/Commands/Edit/AutoParametersCommand.swift
@@ -46,7 +46,7 @@ extension PoieticTool {
             }
 
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
             
             if result.added.count + result.removed.count > 0 {
                 print("Added \(result.added.count) edges and removed \(result.removed.count) edges.")

--- a/Sources/Commands/Edit/ConnectCommand.swift
+++ b/Sources/Commands/Edit/ConnectCommand.swift
@@ -66,7 +66,7 @@ extension PoieticTool {
             let id = trans.create(type, structure: .edge(originObject.id, targetObject.id))
             
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
 
             print("Created edge \(id)")
         }

--- a/Sources/Commands/Edit/CreateFrameCommand.swift
+++ b/Sources/Commands/Edit/CreateFrameCommand.swift
@@ -108,7 +108,7 @@ Note: Frame with requested IDs can not be --forced to be replaced. Remove the fr
                 createdRef = frame.id.stringValue
             }
 
-            try env.close()
+            try env.closeAndSave()
 
             print("Created frame \(createdRef)")
         }

--- a/Sources/Commands/Edit/LayoutCommand.swift
+++ b/Sources/Commands/Edit/LayoutCommand.swift
@@ -67,7 +67,7 @@ extension PoieticTool {
             }
             
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
         }
     }
 }

--- a/Sources/Commands/Edit/PruneHistoryCommand.swift
+++ b/Sources/Commands/Edit/PruneHistoryCommand.swift
@@ -32,7 +32,7 @@ extension PoieticTool {
                 env.design.removeFrame(frame)
             }
 
-            try env.close()
+            try env.closeAndSave()
             
             if count > 0 {
                 print("Removed \(count) frames.")

--- a/Sources/Commands/Edit/RemoveFrameCommand.swift
+++ b/Sources/Commands/Edit/RemoveFrameCommand.swift
@@ -51,7 +51,7 @@ extension PoieticTool {
                 env.design.removeFrame(id)
             }
 
-            try env.close()
+            try env.closeAndSave()
             
             print("Removed \(toRemove.count) frames.")
         }

--- a/Sources/Commands/Edit/RemoveNodeCommand.swift
+++ b/Sources/Commands/Edit/RemoveNodeCommand.swift
@@ -35,7 +35,7 @@ extension PoieticTool {
             let removed = trans.removeCascading(object.id)
 
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
 
             print("Removed object: \(object.id)")
             if !removed.isEmpty {

--- a/Sources/Commands/Edit/SetAttributeCommand.swift
+++ b/Sources/Commands/Edit/SetAttributeCommand.swift
@@ -47,7 +47,7 @@ extension PoieticTool {
                                        string: value)
             
             try env.accept(trans, replacing: options.replaceRef, appendHistory: options.appendHistory)
-            try env.close()
+            try env.closeAndSave()
             
             print("Property set in \(reference): \(attributeName) = \(value)")
         }

--- a/Sources/Commands/Edit/UndoRedoCommands.swift
+++ b/Sources/Commands/Edit/UndoRedoCommands.swift
@@ -27,7 +27,7 @@ extension PoieticTool {
             let frameID = env.design.undoableFrames.last!
             env.design.undo(to: frameID)
 
-            try env.close()
+            try env.closeAndSave()
             print("Did undo")
         }
     }
@@ -53,7 +53,7 @@ extension PoieticTool {
             let frameID = env.design.redoableFrames.first!
             env.design.redo(to: frameID)
 
-            try env.close()
+            try env.closeAndSave()
             print("Did redo.")
         }
     }

--- a/Sources/Commands/ExportCommand.swift
+++ b/Sources/Commands/ExportCommand.swift
@@ -52,7 +52,7 @@ extension PoieticTool {
                 frameID = id
             }
             let frame = env.design.frame(frameID)!
-            let extractor = RawDesignExtractor()
+            let extractor = DesignExtractor()
             let snapshots: [RawSnapshot]
             if references.isEmpty {
                 snapshots = frame.snapshots.map {

--- a/Sources/Commands/ExportCommand.swift
+++ b/Sources/Commands/ExportCommand.swift
@@ -1,0 +1,96 @@
+//
+//  Import.swift
+//  
+//
+//  Created by Stefan Urbanek on 14/08/2023.
+//
+
+@preconcurrency import ArgumentParser
+import Foundation
+import PoieticCore
+import PoieticFlows
+
+// TODO: Merge with PrintCommand, use --format=id
+extension PoieticTool {
+    struct Export: ParsableCommand {
+        static let configuration
+            = CommandConfiguration(abstract: "Export current frame or a collection of objects")
+        
+        @OptionGroup var globalOptions: Options
+
+        @Option(name: [.customLong("frame")], help: "Frame to be exported. Default: current frame.")
+        var frameReference: String?
+
+        @Option(name: [.customLong("output"), .customShort("o")], help: "Output path. Default or '-' is standard output.")
+        var outputPath: String = "-"
+
+        @Argument(help: "List of references of objects to be exported. Default: all objects in a frame.")
+        var references: [String] = []
+
+        mutating func run() throws {
+            let env = try ToolEnvironment(location: globalOptions.designLocation)
+            guard env.design.frames.count > 0 else {
+                throw ToolError.emptyDesign
+            }
+            let frameID: ObjectID
+            if let frameReference {
+                if let id = env.design.frame(name: frameReference)?.id {
+                    frameID = id
+                }
+                else if let id = ObjectID(frameReference), env.design.containsFrame(id) {
+                    frameID = id
+                }
+                else {
+                    throw ToolError.unknownFrame(frameReference)
+
+                }
+            }
+            else {
+                guard let id = env.design.currentFrameID else {
+                    throw ToolError.unknownFrame("<current frame>")
+                }
+                frameID = id
+            }
+            let frame = env.design.frame(frameID)!
+            let extractor = RawDesignExtractor()
+            let snapshots: [RawSnapshot]
+            if references.isEmpty {
+                snapshots = frame.snapshots.map {
+                    extractor.extract($0)
+                }
+            }
+            else {
+                var validIDs: [ObjectID] = []
+                for ref in references {
+                    guard let snapshot = frame.object(stringReference: ref) else {
+                        throw ToolError.unknownObject(ref)
+                    }
+                    validIDs.append(snapshot.id)
+                }
+                snapshots = extractor.extractPruning(snapshots: validIDs, frame: frame)
+            }
+
+            let rawDesign = extractor.extractStub(env.design)
+            rawDesign.snapshots = snapshots
+            
+            let writer = JSONDesignWriter()
+            if outputPath == "-" {
+                let data = writer.write(rawDesign)
+                if let string = String(data: data, encoding: .utf8) {
+                    print(string)
+                }
+            }
+            else {
+                let url = URL(filePath: outputPath)
+                do {
+                    try writer.write(rawDesign, toURL: url)
+                }
+                catch {
+                    // TODO Add tool error
+                    fatalError("Unable to write to \(url): \(error)")
+                }
+            }
+        }
+    }
+}
+

--- a/Sources/Commands/ImportCommand.swift
+++ b/Sources/Commands/ImportCommand.swift
@@ -30,7 +30,7 @@ extension PoieticTool {
             let trans = try env.deriveOrCreate(options.deriveRef)
 
             let rawDesign = try readRawDesign(fromPath: fileName)
-            let loader = RawDesignLoader(metamodel: StockFlowMetamodel, options: .useIDAsNameAttribute)
+            let loader = DesignLoader(metamodel: StockFlowMetamodel, options: .useIDAsNameAttribute)
             do {
                 // FIXME: [WIP] add which frame to load
                 try loader.load(rawDesign.snapshots, into: trans)

--- a/Sources/Commands/ImportCommand.swift
+++ b/Sources/Commands/ImportCommand.swift
@@ -19,7 +19,10 @@ extension PoieticTool {
         @OptionGroup var globalOptions: Options
         @OptionGroup var options: EditOptions
 
-        @Argument(help: "Path to a frame bundle to import")
+        // TODO: Specify which frame to import from a multi-frame file
+        // TODO: Fail on multi-frame file without current frame
+        
+        @Argument(help: "Path to a poietic design to import from")
         var fileName: String
         
         mutating func run() throws {
@@ -27,7 +30,7 @@ extension PoieticTool {
             let trans = try env.deriveOrCreate(options.deriveRef)
 
             let rawDesign = try readRawDesign(fromPath: fileName)
-            let loader = RawDesignLoader(metamodel: StockFlowMetamodel, options: .nameFromID)
+            let loader = RawDesignLoader(metamodel: StockFlowMetamodel, options: .useIDAsNameAttribute)
             do {
                 // FIXME: [WIP] add which frame to load
                 try loader.load(rawDesign.snapshots, into: trans)

--- a/Sources/Commands/MetamodelCommand.swift
+++ b/Sources/Commands/MetamodelCommand.swift
@@ -52,7 +52,7 @@ extension PoieticTool {
             else {
                 printAll(metamodel, format: outputFormat)
             }
-            try env.close()
+            try env.closeAndSave()
         }
         
         func printType(_ type: ObjectType,

--- a/Sources/Commands/NewCommand.swift
+++ b/Sources/Commands/NewCommand.swift
@@ -28,7 +28,7 @@ extension PoieticTool {
             let env = try ToolEnvironment(location: options.designLocation, design: design)
 
             if !importPaths.isEmpty {
-                let loader = RawDesignLoader(metamodel: design.metamodel, options: .useIDAsNameAttribute)
+                let loader = DesignLoader(metamodel: design.metamodel, options: .useIDAsNameAttribute)
                 let frame = design.createFrame()
 
                 for path in importPaths {

--- a/Sources/Commands/NewCommand.swift
+++ b/Sources/Commands/NewCommand.swift
@@ -28,7 +28,7 @@ extension PoieticTool {
             let env = try ToolEnvironment(location: options.designLocation, design: design)
 
             if !importPaths.isEmpty {
-                let loader = RawDesignLoader(metamodel: design.metamodel, options: .nameFromID)
+                let loader = RawDesignLoader(metamodel: design.metamodel, options: .useIDAsNameAttribute)
                 let frame = design.createFrame()
 
                 for path in importPaths {

--- a/Sources/Commands/ShowCommand.swift
+++ b/Sources/Commands/ShowCommand.swift
@@ -7,6 +7,7 @@
 
 @preconcurrency import ArgumentParser
 import PoieticCore
+import Foundation
 
 /// Width of the attribute label column for right-aligned display.
 ///
@@ -123,7 +124,9 @@ func printObjectAsText(_ object: DesignObject) {
 }
 
 func printObjectAsJSON(_ object: DesignObject) {
-    let data = try! JSONFrameWriter.objectToJSON(object)
+    let raw = RawSnapshot(object)
+    let encoder = JSONEncoder()
+    let data = try! encoder.encode(raw)
     let output = String(data: data, encoding: .utf8)!
     print(output)
 }

--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -26,7 +26,7 @@ enum ToolError: Error, CustomStringConvertible {
     case unableToSaveDesign(Error)
     case storeError(DesignStoreError)
     case designReaderError(RawDesignReaderError, URL?)
-    case designLoaderError(RawDesignLoaderError, URL?)
+    case designLoaderError(DesignLoaderError, URL?)
     case emptyDesign
     
     // Design errors

--- a/Sources/PoieticTool.swift
+++ b/Sources/PoieticTool.swift
@@ -24,7 +24,7 @@ struct PoieticTool: ParsableCommand {
             Edit.self,
 //            Print.self,
             Import.self,
-//            Export.self,
+            Export.self,
             Run.self,
             WriteDOT.self,
             MetamodelCommand.self,

--- a/Sources/ToolEnvironment.swift
+++ b/Sources/ToolEnvironment.swift
@@ -65,7 +65,7 @@ class ToolEnvironment {
             self.design = design
         }
         else {
-            let store = MakeshiftDesignStore(url: url)
+            let store = DesignStore(url: url)
             let design: Design
             do {
                 // TODO: remove the metamodel here
@@ -239,11 +239,12 @@ class ToolEnvironment {
             }
         }
     }
-    
-    func close() throws (ToolError) {
+
+    /// Close with saving the modified design.
+    func closeAndSave() throws (ToolError) {
         precondition(isOpen, "Trying to close already closed design: \(url)")
         
-        let store = MakeshiftDesignStore(url: url)
+        let store = DesignStore(url: url)
         do {
             try store.save(design: design)
         }
@@ -252,6 +253,14 @@ class ToolEnvironment {
         }
         isOpen = false
     }
+    
+    /// Close without saving the design.
+    ///
+    func close() throws (ToolError) {
+        precondition(isOpen, "Trying to close already closed design: \(url)")
+        isOpen = false
+    }
+
 }
 
 


### PR DESCRIPTION
- Use new raw design loading in the Import and New commands
- Use RawSnapshot in JSON writing (Show command)
- Use new design store based on Raw objects, removed Makeshift store
- distinct environment closing with and without saving
- bumped requirement to MacOS 15